### PR TITLE
Destroy magic methods

### DIFF
--- a/lib/TreasureChest/Instance.php
+++ b/lib/TreasureChest/Instance.php
@@ -86,7 +86,7 @@ class Instance implements CacheInterface
 	 */
 	public function add($key, $var = null, $ttl = 0)
 	{
-		return $this->_callCacheMethod('add', func_get_args());
+		return $this->callCacheMethod('add', func_get_args());
 	}
 
 	/**
@@ -100,7 +100,7 @@ class Instance implements CacheInterface
 	 */
 	public function store($key, $var = null, $ttl = 0)
 	{
-		return $this->_callCacheMethod('store', func_get_args());
+		return $this->callCacheMethod('store', func_get_args());
 	}
 
 	/**
@@ -113,7 +113,7 @@ class Instance implements CacheInterface
 	 */
 	public function replace($key, $var = null, $ttl = 0)
 	{
-		return $this->_callCacheMethod('replace', func_get_args());
+		return $this->callCacheMethod('replace', func_get_args());
 	}
 
 	/**
@@ -123,7 +123,7 @@ class Instance implements CacheInterface
 	 */
 	public function exists($key)
 	{
-		return $this->_callCacheMethod('exists', func_get_args());
+		return $this->callCacheMethod('exists', func_get_args());
 	}
 
 	/**
@@ -135,7 +135,7 @@ class Instance implements CacheInterface
 	 */
 	public function fetch($key, &$success = false)
 	{
-		return $this->_callCacheMethod('fetch', func_get_args());
+		return $this->callCacheMethod('fetch', func_get_args());
 	}
 
 	/**
@@ -148,7 +148,7 @@ class Instance implements CacheInterface
 	 */
 	public function inc($key, $step = 1, &$success = null)
 	{
-		return $this->_callCacheMethod('inc', func_get_args());
+		return $this->callCacheMethod('inc', func_get_args());
 	}
 
 	/**
@@ -161,7 +161,7 @@ class Instance implements CacheInterface
 	 */
 	public function dec($key, $step = 1, &$success = null)
 	{
-		return $this->_callCacheMethod('dec', func_get_args());
+		return $this->callCacheMethod('dec', func_get_args());
 	}
 
 	/**
@@ -171,7 +171,7 @@ class Instance implements CacheInterface
 	 */
 	public function delete($key)
 	{
-		return $this->_callCacheMethod('delete', func_get_args());
+		return $this->callCacheMethod('delete', func_get_args());
 	}
 
 	/**
@@ -179,7 +179,7 @@ class Instance implements CacheInterface
 	 */
 	public function clear()
 	{
-		return $this->_callCacheMethod('clear', func_get_args());
+		return $this->callCacheMethod('clear', func_get_args());
 	}
 
 	/**
@@ -208,7 +208,7 @@ class Instance implements CacheInterface
 	 *
 	 * @return mixed          Result of calling the method on the cache instance
 	 */
-	protected function _callCacheMethod($method, array $args = array())
+	protected function callCacheMethod($method, array $args = array())
 	{
 		if (isset($args[0])) {
 			// If we are auto prefixing all keys with a namespace, do that here

--- a/lib/TreasureChest/Instance.php
+++ b/lib/TreasureChest/Instance.php
@@ -7,73 +7,57 @@
  * This gives the ability to logically group a set of keys and invalidate
  * them all at once making cache management easier.
  * Note: This library requires APC version 3.1.4 or higher.
- * 
+ *
  * @author James Moss <email@jamesmoss.co.uk>
- * @version 0.2
- * @package namespace-cache
+ * @version 0.1.4
+ * @package treasure-chest
  */
- 
- 
+
+
 namespace TreasureChest;
- 
-class Instance
-{	
+
+class Instance implements CacheInterface
+{
 	/**
 	 * The character used to indicate the seperation of cache namespaces
 	 *
-	 * @var string 
+	 * @var string
 	 */
 	protected $delimiter = ':';
 
 	/**
-	 * This namespace can be appended to the start of all other keys passed in to 
+	 * This namespace can be appended to the start of all other keys passed in to
 	 * the class to faciliate logical partitioning of cache data.
 	 *
-	 * @var string 
+	 * @var string
 	 */
 	protected $prefix = '';
-	
-	public function __construct($cache)
+
+	/**
+	 * Constructor.
+	 *
+	 * @param CacheInterface $cache The cache instance to use
+	 */
+	public function __construct(CacheInterface $cache)
 	{
-		$this->cache = $cache;
+		$this->cache  = $cache;
 		$this->mapper = new KeyMapper($this->cache, $this->delimiter);
 	}
-	
-	public function __call($method, $args)
-	{
-		// Only the methods from the CacheInterface are allowed to be called
-		$allowedMethods = get_class_methods('\\'.__NAMESPACE__.'\\CacheInterface');
-		
-		if(!in_array($method, $allowedMethods)) {
-			throw new Exception('Unknown method '.$method);
-		}
 
-		// If we are auto prefixing all keys with a namespace, do that here
-		if($this->prefix) {
-			$args[0] = $this->prefix.$this->delimiter.$args[0];
-		}
-		
-		// convert the user supplied key into one actually used in the cache
-		$args[0] = $this->mapper->parse($args[0]);
-		
-		// Call the method on the cache class, passing in supplied arguments
-		return call_user_func_array(array($this->cache, $method), $args);
-	}
-	
 	/**
 	 * Sets the current version of the provided namespace
 	 *
-	 * @param string $prefix The new prefix to use 
+	 * @param string $prefix The new prefix to use
 	 */
 	public function setPrefix($prefix)
 	{
 		$this->prefix = $prefix;
 	}
-	
+
 	/**
 	 * Sets the namespace delimiter
 	 *
-	 * @param string $prefix The new delimiter to use 
+	 * @param string $prefix The new delimiter to use
 	 */
 	public function setDelimiter($delimiter)
 	{
@@ -83,7 +67,7 @@ class Instance
 
 	/**
 	 * Set your own custom mapper.
-	 * 
+	 *
 	 * @param KeyMapperInterface $mapper [description]
 	 */
 	public function setMapper(KeyMapperInterface $mapper)
@@ -91,7 +75,52 @@ class Instance
 		$this->mapper = $mapper;
 		$this->mapper->setDelimiter($this->delimiter);
 	}
-	
+
+	public function add($key, $var = null, $ttl = 0)
+	{
+		return $this->_callCacheMethod('add', func_get_args());
+	}
+
+	public function store($key, $var = null, $ttl = 0)
+	{
+		return $this->_callCacheMethod('store', func_get_args());
+	}
+
+	public function replace($key, $var = null, $ttl = 0)
+	{
+		return $this->_callCacheMethod('replace', func_get_args());
+	}
+
+	public function exists($key)
+	{
+		return $this->_callCacheMethod('exists', func_get_args());
+	}
+
+	public function fetch($key, &$success = false)
+	{
+		return $this->_callCacheMethod('fetch', func_get_args());
+	}
+
+	public function inc($key, $step = 1, &$success = null)
+	{
+		return $this->_callCacheMethod('inc', func_get_args());
+	}
+
+	public function dec($key, $step = 1, &$success = null)
+	{
+		return $this->_callCacheMethod('dec', func_get_args());
+	}
+
+	public function delete($key)
+	{
+		return $this->_callCacheMethod('delete', func_get_args());
+	}
+
+	public function clear()
+	{
+		return $this->_callCacheMethod('clear', func_get_args());
+	}
+
 	/**
 	 * Deletes all the keys in an entire namespace.
 	 *
@@ -104,5 +133,33 @@ class Instance
 		}
 
 		return $this->mapper->invalidate($namespace);
+	}
+
+	/**
+	 * Call a given method on the stored cache instance.
+	 *
+	 * This is used with specific methods, rather than using the `__call()`
+	 * magic method so that we can use an interface to define the methods. This
+	 * makes this class easier to hint in your application.
+	 *
+	 * @param  string $method Method name to call
+	 * @param  array  $args   Arguments to use
+	 *
+	 * @return mixed          Result of calling the method on the cache instance
+	 */
+	protected function _callCacheMethod($method, array $args = array())
+	{
+		if (isset($args[0])) {
+			// If we are auto prefixing all keys with a namespace, do that here
+			if($this->prefix) {
+				$args[0] = $this->prefix.$this->delimiter.$args[0];
+			}
+
+			// Convert the user supplied key into one actually used in the cache
+			$args[0] = $this->mapper->parse($args[0]);
+		}
+
+		// Call the method on the cache class, passing in supplied arguments
+		return call_user_func_array(array($this->cache, $method), $args);
 	}
 }

--- a/lib/TreasureChest/Instance.php
+++ b/lib/TreasureChest/Instance.php
@@ -76,46 +76,107 @@ class Instance implements CacheInterface
 		$this->mapper->setDelimiter($this->delimiter);
 	}
 
+	/**
+	 * Store a variable in the cache if it doesn't already exist.
+	 *
+	 * @param string  $key Key to use when storing this variable
+	 * @param mixed   $var Variable to store
+	 * @param integer $ttl Number of seconds to store this variable for, setting
+	 *                     to 0 means it will never expire
+	 */
 	public function add($key, $var = null, $ttl = 0)
 	{
 		return $this->_callCacheMethod('add', func_get_args());
 	}
 
+	/**
+	 * Store a variable in the cache, overwriting any saved variable of the same
+	 * name.
+	 *
+	 * @param string  $key Key to use when storing this variable
+	 * @param mixed   $var Variable to store
+	 * @param integer $ttl Number of seconds to store this variable for, setting
+	 *                     to 0 means it will never expire
+	 */
 	public function store($key, $var = null, $ttl = 0)
 	{
 		return $this->_callCacheMethod('store', func_get_args());
 	}
 
+	/**
+	 * Replace a variable in the cache, only if it already exists.
+	 *
+	 * @param string  $key Key to use when storing this variable
+	 * @param mixed   $var Variable to store
+	 * @param integer $ttl Number of seconds to store this variable for, setting
+	 *                     to 0 means it will never expire
+	 */
 	public function replace($key, $var = null, $ttl = 0)
 	{
 		return $this->_callCacheMethod('replace', func_get_args());
 	}
 
+	/**
+	 * Check if a given key exists in the cache.
+	 *
+	 * @param string $key Check for variable assigned to this key
+	 */
 	public function exists($key)
 	{
 		return $this->_callCacheMethod('exists', func_get_args());
 	}
 
+	/**
+	 * Fetch a stored variable from the cache.
+	 *
+	 * @param string $key     Fetch variable assigned to this key
+	 * @param bool   $success Referenced variable to store the result, true if
+	 *                        successful, false otherwise
+	 */
 	public function fetch($key, &$success = false)
 	{
 		return $this->_callCacheMethod('fetch', func_get_args());
 	}
 
+	/**
+	 * Atomically increment a stored number in the cache.
+	 *
+	 * @param string $key     Fetch variable assigned to this key
+	 * @param int    $step    Amount to increment by
+	 * @param bool   $success Referenced variable to store the result, true if
+	 *                        successful, false otherwise
+	 */
 	public function inc($key, $step = 1, &$success = null)
 	{
 		return $this->_callCacheMethod('inc', func_get_args());
 	}
 
+	/**
+	 * Atomically decrement a stored number in the cache.
+	 *
+	 * @param string $key     Fetch variable assigned to this key
+	 * @param int    $step    Amount to decrement by
+	 * @param bool   $success Referenced variable to store the result, true if
+	 *                        successful, false otherwise
+	 */
 	public function dec($key, $step = 1, &$success = null)
 	{
 		return $this->_callCacheMethod('dec', func_get_args());
 	}
 
+	/**
+	 * Delete an individual variable from the cache.
+	 *
+	 * @param string $key Delete variable assigned to this key
+	 */
 	public function delete($key)
 	{
 		return $this->_callCacheMethod('delete', func_get_args());
 	}
 
+	/**
+	 * Clear the entire cache.
+	 */
 	public function clear()
 	{
 		return $this->_callCacheMethod('clear', func_get_args());

--- a/tests/TreasureChest/InstanceTest.php
+++ b/tests/TreasureChest/InstanceTest.php
@@ -4,13 +4,81 @@ namespace TreasureChest;
 
 class InstanceTest extends \PHPUnit_Framework_TestCase
 {
-	/**
-	 * @expectedException TreasureChest\Exception
-	 */
-	public function testNonExistantMethod()
+	public function testCallingCacheMethods()
 	{
-		$cache = new Instance(new Cache\Filesystem('/tmp'));
+		$cache    = $this->getMock('TreasureChest\CacheInterface');
+		$instance = new Instance($cache);
+		$cacheKey = 'testKey';
 
-		$cache->flubble('user123:username');
+		$cache
+			->expects($this->exactly(1))
+			->method('exists')
+			->with($cacheKey)
+			->will($this->returnValue(false));
+
+		$this->assertFalse($instance->exists($cacheKey));
+
+		$cache
+			->expects($this->exactly(1))
+			->method('add')
+			->with($cacheKey, 'my value', 5)
+			->will($this->returnValue(true));
+
+		$this->assertTrue($instance->add($cacheKey, 'my value', 5));
+
+		$cache
+			->expects($this->exactly(1))
+			->method('store')
+			->with($cacheKey, 'my value', 5)
+			->will($this->returnValue(true));
+
+		$this->assertTrue($instance->store($cacheKey, 'my value', 5));
+
+		$cache
+			->expects($this->exactly(1))
+			->method('replace')
+			->with($cacheKey, 'my value', 5)
+			->will($this->returnValue(true));
+
+		$this->assertTrue($instance->replace($cacheKey, 'my value', 5));
+
+		$cache
+			->expects($this->exactly(1))
+			->method('fetch')
+			->with($cacheKey)
+			->will($this->returnValue('test'));
+
+		$this->assertEquals('test', $instance->fetch($cacheKey));
+
+		$cache
+			->expects($this->exactly(1))
+			->method('inc')
+			->with($cacheKey)
+			->will($this->returnValue(true));
+
+		$this->assertTrue($instance->inc($cacheKey));
+
+		$cache
+			->expects($this->exactly(1))
+			->method('dec')
+			->with($cacheKey)
+			->will($this->returnValue(true));
+
+		$this->assertTrue($instance->dec($cacheKey));
+
+		$cache
+			->expects($this->exactly(1))
+			->method('delete')
+			->with($cacheKey)
+			->will($this->returnValue(true));
+
+		$this->assertTrue($instance->delete($cacheKey));
+
+		$cache
+			->expects($this->exactly(1))
+			->method('clear')
+			->will($this->returnValue(true));
+
+		$this->assertTrue($instance->clear());
 	}
 }


### PR DESCRIPTION
We want to avoid using `__call()` and also want to be able to hint `Interface` using `CacheInterface`. This PR enables this functionality and gets rid of the magic method.

Also added some unit tests for these new methods.
